### PR TITLE
Avoid dependency on `ext-filter`

### DIFF
--- a/src/SshSocksConnector.php
+++ b/src/SshSocksConnector.php
@@ -78,7 +78,7 @@ class SshSocksConnector implements ConnectorInterface
         \parse_str(parse_url($uri, \PHP_URL_QUERY), $args);
         if (isset($args['bind'])) {
             $parts = parse_url('tcp://' . $args['bind']);
-            if (!isset($parts['scheme'], $parts['host'], $parts['port']) || \filter_var(\trim($parts['host'], '[]'), \FILTER_VALIDATE_IP) === false) {
+            if (!isset($parts['scheme'], $parts['host'], $parts['port']) || @\inet_pton(\trim($parts['host'], '[]')) === false) {
                 throw new \InvalidArgumentException('Invalid bind address given');
             }
             $this->bind = $args['bind'];


### PR DESCRIPTION
This simple changeset avoids an unneeded (and undeclared!) dependency on `ext-filter`. The extension is enabled by default, but can explicitly be disabled with `--without-filter`.

The code in question is already covered by the test suite, so the test suite confirms this changeset does not affect behavior or our public API in any way. Accordingly, this is entirely transparent for all consumers of this package, plus now also supports consumers that happen use `--without-filter`.

The changes have been ported from https://github.com/reactphp/dns/pull/185
See https://www.php.net/manual/en/filter.installation.php
Originally reported in https://github.com/leproxy/leproxy/issues/80
Refs https://github.com/reactphp/socket/pull/17