### PR TITLE
Mark passwords and URIs as `#[\SensitiveParameter]` (PHP 8.2+)

### DIFF
--- a/src/SshProcessConnector.php
+++ b/src/SshProcessConnector.php
@@ -38,8 +38,11 @@ class SshProcessConnector implements ConnectorInterface
      * @param ?LoopInterface $loop
      * @throws \InvalidArgumentException
      */
-    public function __construct($uri, LoopInterface $loop = null)
-    {
+    public function __construct(
+        #[\SensitiveParameter]
+        $uri,
+        LoopInterface $loop = null
+    ) {
         // URI must use optional ssh:// scheme, must contain host and neither pass nor target must start with dash
         $parts = \parse_url((\strpos($uri, '://') === false ? 'ssh://' : '') . $uri);
         $pass = isset($parts['pass']) ? \rawurldecode($parts['pass']) : null;

--- a/src/SshSocksConnector.php
+++ b/src/SshSocksConnector.php
@@ -49,8 +49,11 @@ class SshSocksConnector implements ConnectorInterface
      * @param ?LoopInterface $loop
      * @throws \InvalidArgumentException
      */
-    public function __construct($uri, LoopInterface $loop = null)
-    {
+    public function __construct(
+        #[\SensitiveParameter]
+        $uri,
+        LoopInterface $loop = null
+    ) {
         // URI must use optional ssh:// scheme, must contain host and neither pass nor target must start with dash
         $parts = \parse_url((\strpos($uri, '://') === false ? 'ssh://' : '') . $uri);
         $pass = isset($parts['pass']) ? \rawurldecode($parts['pass']) : null;


### PR DESCRIPTION
As @clue describes in https://github.com/friends-of-reactphp/mysql/pull/162:

> This changeset marks all passwords and URIs containing passwords as `#[\SensitiveParameter]` to avoid these parameter from potentially showing up in exception traces in PHP 8.2+. Older PHP versions are not affected by this change and continue to work as is. See also RFC: https://wiki.php.net/rfc/redact_parameters_in_back_traces

Refs #37 