### PR TITLE
Run tests on PHP 8.3, fix dynamic property for PHP 8.2 and update test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         php:
+          - 8.3
           - 8.2
           - 8.1
           - 8.0
@@ -24,7 +25,7 @@ jobs:
           - 5.4
           - 5.3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -39,13 +40,16 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
+      - uses: actions/checkout@v4
+      - run: cp "$(which composer)" composer.phar && ./composer.phar self-update --2.2 # downgrade Composer for HHVM
+      - name: Run hhvm composer.phar install
+        uses: docker://hhvm/hhvm:3.30-lts-latest
         with:
-          version: lts-3.30
-      - run: composer self-update --2.2 # downgrade Composer for HHVM
-      - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit
+          args: hhvm composer.phar install
+      - name: Run hhvm vendor/bin/phpunit
+        uses: docker://hhvm/hhvm:3.30-lts-latest
+        with:
+          args: hhvm vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,23 @@
         "react/stream": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36",
+        "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
         "react/async": "^4 || ^3 || ^2",
         "react/http": "^1.5",
-        "react/mysql": "^0.5.5"
+        "react/mysql": "^0.5.5",
+        "react/promise-timer": "^1.11"
     },
     "autoload": {
-        "psr-4": { "Clue\\React\\SshProxy\\": "src/" },
-        "files": [ "src/Io/functions.php" ]
+        "psr-4": {
+            "Clue\\React\\SshProxy\\": "src/"
+        },
+        "files": [
+            "src/Io/functions.php"
+        ]
     },
     "autoload-dev": {
-        "psr-4": { "Clue\\Tests\\React\\SshProxy\\": "tests/"} 
+        "psr-4": {
+            "Clue\\Tests\\React\\SshProxy\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+<!-- PHPUnit configuration file with new format for PHPUnit 9.6+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          cacheResult="false"
          colors="true"
@@ -17,4 +17,7 @@
             <directory>./src/</directory>
         </include>
     </coverage>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<!-- PHPUnit configuration file with old format for legacy PHPUnit -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
          bootstrap="vendor/autoload.php"
@@ -15,4 +15,7 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
 </phpunit>

--- a/src/Io/CompositeConnection.php
+++ b/src/Io/CompositeConnection.php
@@ -73,7 +73,6 @@ class CompositeConnection extends EventEmitter implements ConnectionInterface
             return;
         }
 
-        $this->remote = null;
         $this->closed = true;
         $this->read->close();
         $this->write->close();


### PR DESCRIPTION
Builds on top of #32, #37 and #39.

References: https://github.com/reactphp/socket/pull/300, https://github.com/clue/reactphp-zenity/pull/63, https://github.com/clue/reactphp-csv/pull/33 and others.

The tests were failing in PHP 5.3 because of an unknown `React\Promise\Timer\sleep()` function. In order to avoid this I updated this to use the `React\Async\delay()` function instead.

Additionally I saw the dynamic properties were deprecated since PHP 8.2, see https://www.php.net/releases/8.2/en.php#deprecate_dynamic_properties, so I had to add a new class variable in the `CompositeConnection.php` file to avoid that the test for PHP 8.2 and PHP 8.3 run infinitely.